### PR TITLE
各画像が何回使用されているかを出力するメソッドを追加

### DIFF
--- a/lib/image_file_counter/core/get_files.rb
+++ b/lib/image_file_counter/core/get_files.rb
@@ -29,7 +29,7 @@ module ImageFileCounter
       return [] if files_path.nil?
 
       view_files_and_rb_files = files_path.select do |file|
-        file.include?('.rb') || file.include?('.html.haml') || file.include?('.slim') || file.include?('.erb')
+        file.include?('.html.haml') || file.include?('.slim') || file.include?('.erb')
       end
       return 'View files and Ruby files count is 0' if view_files_and_rb_files.count.zero?
 

--- a/lib/image_file_counter/core/get_files.rb
+++ b/lib/image_file_counter/core/get_files.rb
@@ -16,8 +16,8 @@ module ImageFileCounter
       return ['nothings'] if files_path.nil?
 
       select_image_files = files_path.select do |file|
-        if  file.include?('.webp') || file.include?('.jpeg') || file.include?('.jpg') || file.include?('.png') || file.include?('.svg')
-          file.gsub!(/.[\/0-9a-zA-Z_-]+\/image\//, '')
+        if file.include?('.webp') || file.include?('.jpeg') || file.include?('.jpg') || file.include?('.png') || file.include?('.svg')
+          file.gsub!(%r{.[/0-9a-zA-Z_-]+/image/}, '')
         end
       end
       return 'Image files count is 0' if select_image_files.count.zero?
@@ -48,7 +48,7 @@ module ImageFileCounter
       imags_file_name = select_image_files(files_name)
       result = {}
 
-      return puts "files_path is nil" if view_files_path.nil? || imags_file_name.nil?
+      return puts 'files_path is nil' if view_files_path.nil? || imags_file_name.nil?
 
       imags_file_name.each do |image|
         image_count = 0
@@ -61,9 +61,9 @@ module ImageFileCounter
         result = { image => image_count }
       end
 
-      puts "IMAGE COUNT RESULT"
-      result.each do |k,v|
-        puts "#{k}: #{"*" * v}"
+      puts 'IMAGE COUNT RESULT'
+      result.each do |k, v|
+        puts "#{k}: #{'*' * v}"
       end
     end
   end

--- a/lib/image_file_counter/core/get_files.rb
+++ b/lib/image_file_counter/core/get_files.rb
@@ -33,9 +33,6 @@ module ImageFileCounter
       end
       return 'View files and Ruby files count is 0' if view_files_and_rb_files.count.zero?
 
-      view_files_and_rb_files.map do |file|
-        puts file
-      end
       view_files_and_rb_files
     end
 

--- a/lib/image_file_counter/core/get_files.rb
+++ b/lib/image_file_counter/core/get_files.rb
@@ -16,7 +16,9 @@ module ImageFileCounter
       return ['nothings'] if files_path.nil?
 
       select_image_files = files_path.select do |file|
-        file.include?('.jpeg') || file.include?('.jpg') || file.include?('.png') || file.include?('.svg')
+        if file.include?('.jpeg') || file.include?('.jpg') || file.include?('.png') || file.include?('.svg')
+          file.gsub!(/.[\/0-9a-zA-Z_-]+\/image\//, '')
+        end
       end
       return 'Image files count is 0' if select_image_files.count.zero?
 
@@ -37,13 +39,35 @@ module ImageFileCounter
       view_files_and_rb_files
     end
 
-    def count_images_in_view_file(files_path, image_name)
+    def self.count_images_in_view_file
       # select_view_files_and_ruby_filesからの返り値を使用して、それぞれのファイルでgrepを行う。
       # select_image_filesの画像がヒットするかを判別する。
       # ヒットした画像のパスが何回登場したのかを配列に持たせる。
       # できれば、それをグラフ化したい。簡易的ならこんな感じ
       # kojo: ********
       # aoki: ****
+      files_name = generate_files_name
+      view_files_path = select_view_files_and_ruby_files(files_name)
+      imags_file_name = select_image_files(files_name)
+      result = {}
+
+      return puts "files_path is nil" if view_files_path.nil? || imags_file_name.nil?
+
+      imags_file_name.each do |image|
+        image_count = 0
+        view_files_path.each do |file_path|
+          command = "rg \"#{image}\" #{file_path}"
+          puts command
+          stdout, stderr, status = Open3.capture3(command)
+          image_count += stdout.split("\n").count
+          puts image_count
+        end
+        result = { image => image_count }
+      end
+
+      result.each do |k,v|
+        puts "#{k} : #{v}回使用されています"
+      end
     end
   end
 end

--- a/lib/image_file_counter/core/get_files.rb
+++ b/lib/image_file_counter/core/get_files.rb
@@ -16,7 +16,7 @@ module ImageFileCounter
       return ['nothings'] if files_path.nil?
 
       select_image_files = files_path.select do |file|
-        if file.include?('.jpeg') || file.include?('.jpg') || file.include?('.png') || file.include?('.svg')
+        if  file.include?('.webp') || file.include?('.jpeg') || file.include?('.jpg') || file.include?('.png') || file.include?('.svg')
           file.gsub!(/.[\/0-9a-zA-Z_-]+\/image\//, '')
         end
       end

--- a/lib/image_file_counter/core/get_files.rb
+++ b/lib/image_file_counter/core/get_files.rb
@@ -54,10 +54,9 @@ module ImageFileCounter
         image_count = 0
         view_files_path.each do |file_path|
           command = "rg \"#{image}\" #{file_path}"
-          puts command
+
           stdout, stderr, status = Open3.capture3(command)
           image_count += stdout.split("\n").count
-          puts image_count
         end
         result = { image => image_count }
       end

--- a/lib/image_file_counter/core/get_files.rb
+++ b/lib/image_file_counter/core/get_files.rb
@@ -62,8 +62,9 @@ module ImageFileCounter
         result = { image => image_count }
       end
 
+      puts "IMAGE COUNT RESULT"
       result.each do |k,v|
-        puts "#{k} : #{v}回使用されています"
+        puts "#{k}: #{"*" * v}"
       end
     end
   end

--- a/lib/image_file_counter_utils/cli.rb
+++ b/lib/image_file_counter_utils/cli.rb
@@ -2,6 +2,7 @@
 
 require 'image_file_counter/core/get_files'
 require 'thor'
+require 'open3'
 
 module ImageFileCounterUtils
   class CLI < Thor
@@ -37,6 +38,11 @@ module ImageFileCounterUtils
     def get_view_files_and_ruby_files
       files_name = ImageFileCounter::Core.get_files_name
       ImageFileCounter::Core.select_view_files_and_ruby_files(files_name)
+    end
+
+    desc 'count_image_file_in_files', 'count image file in files'
+    def count_image_file_in_files
+      ImageFileCounter::Core.count_images_in_view_file
     end
   end
 end

--- a/lib/image_file_counter_utils/cli.rb
+++ b/lib/image_file_counter_utils/cli.rb
@@ -25,18 +25,18 @@ module ImageFileCounterUtils
 
     desc 'get_files_name', 'get files'
     def get_files_name
-      file_name_array = ImageFileCounter::Core.get_files_name
+      file_name_array = ImageFileCounter::Core.generate_files_name
     end
 
     desc 'get_images_files', 'get image files'
     def get_image_files
-      files_name = ImageFileCounter::Core.get_files_name
-      puts ImageFileCounter::Core.select_image_files(files_name)
+      files_name = ImageFileCounter::Core.generate_files_name
+      ImageFileCounter::Core.select_image_files(files_name)
     end
 
     desc 'view_files_and_ruby_files', 'get view files and ruby files'
     def get_view_files_and_ruby_files
-      files_name = ImageFileCounter::Core.get_files_name
+      files_name = ImageFileCounter::Core.generate_files_name
       ImageFileCounter::Core.select_view_files_and_ruby_files(files_name)
     end
 


### PR DESCRIPTION
## 実装したこと
- 各画像が何回使用されているかを出力するメソッドを追加
コマンドを実行するディレクトリ配下にあるビューファイルを全て検索して、画像が何回使用されているのかをカウントする。そして、そのカウント結果を出力するメソッドを作成した。